### PR TITLE
Swap arguments in HotSwapTestCase constructor

### DIFF
--- a/src/tests/hotswap/saHpiHotSwapPolicyCancel/NotPending.cc
+++ b/src/tests/hotswap/saHpiHotSwapPolicyCancel/NotPending.cc
@@ -26,7 +26,7 @@ using namespace ns_saHpiHotSwapPolicyCancel;
  * Constructor
  *****************************************************************************/
 
-NotPending::NotPending(char *line) : HotSwapTestCase(false, line) {
+NotPending::NotPending(char *line) : HotSwapTestCase(line, false) {
 }
 
 /*****************************************************************************


### PR DESCRIPTION
  #21  HotSwapTestCase constructor arguments are wrongly placed.